### PR TITLE
Update fn_MPexec.sqf

### DIFF
--- a/extDB-Build/Altis_Life.Altis/core/functions/network/fn_MPexec.sqf
+++ b/extDB-Build/Altis_Life.Altis/core/functions/network/fn_MPexec.sqf
@@ -29,6 +29,7 @@ _callerUID = [_varValue,7,"",[""]] call bis_fnc_param;
 if(!(["life_fnc_",_functionName] call BIS_fnc_inString) && {!(["SPY_fnc_",_functionName] call BIS_fnc_inString)} && {!(["DB_fnc_",_functionName] call BIS_fnc_inString)} && {!(["TON_fnc_",_functionName] call BIS_fnc_inString)} &&
 {!(toLower(_functionName) in ["bis_fnc_execvm","bis_fnc_effectkilledairdestruction","bis_fnc_effectkilledairdestructionstage2"])} && {!(["SOCK_fnc_",_functionName] call BIS_fnc_inString)}) exitWith {false};
 if(toLower(_functionName) == "db_fnc_asynccall") exitWith {false};
+if(toLower(_functionName) == "db_fnc_mresToArray") exitWith {false};
 
 if(_functionName == "bis_fnc_execvm") then {
 	_param2 = _params select 1;


### PR DESCRIPTION
Didn't confirm in practice, but checked via editor testcode + looking over the code...
This function shouldn't be called by client anyways.


https://github.com/TAWTonic/Altis-Life/blob/master/extDB-Build/life_server/Functions/MySQL/fn_mresToArray.sqf

String supplied by client is
Converted to array
Chars converted
Convert back into string
Call compile, normal this is an string of an array from Database.
But hacker has supplied code as a string, so it gets execute by server

As bonus for hackers, insert string of code in Array for the Database, and it gets executed when loaded.
House Table seems popular since its loaded at server startup.