### PR TITLE
Update fn_clientDisconnect.sqf

### DIFF
--- a/extDB-Build/life_server/Functions/Systems/fn_clientDisconnect.sqf
+++ b/extDB-Build/life_server/Functions/Systems/fn_clientDisconnect.sqf
@@ -10,6 +10,7 @@ _unit = _this select 0;
 _id = _this select 1;
 _uid = _this select 2;
 _name = _this select 3;
+if(isNull _unit) exitWith {};
 
 _containers = nearestObjects[_unit,["WeaponHolderSimulated"],5];
 {deleteVehicle _x;} foreach _containers;


### PR DESCRIPTION
Should fix the following

_containers = nearestObjects[_unit,["WeaponHolderSimul>
 0:45:26   Error position: <nearestObjects[_unit,["WeaponHolderSimul>
 0:45:26   Error deletevehicle: 0 elements provided, 3 expected
 0:45:26 File life_server\Functions\Systems\fn_clientDisconnect.sqf, line 14