### PR TITLE
InsertRequest Error, first login

### DIFF
--- a/extDB-Build/life_server/Functions/MySQL/fn_insertRequest.sqf
+++ b/extDB-Build/life_server/Functions/MySQL/fn_insertRequest.sqf
@@ -13,7 +13,7 @@ params [
 	["_name","",[""]],
 	["_money",0,[""]],
 	["_bank",2500,[""]],
-	["_returnToSender",objNull,objNull]
+	["_returnToSender",objNull,[objNull]]
 ];
 
 //Error checks


### PR DESCRIPTION
Fixed: 
Fixing problem where new players stay on island with no spawn option.

22:11:21 Error in expression <ead","_queryResult","_query","_alias"];
params [
["_uid","",[""]],
["_name","",[>
22:11:21   Error position: <params [
["_uid","",[""]],
["_name","",[>
22:11:21   Error Type Object, expected Array
22:11:21 File life_server\Functions\MySQL\fn_insertRequest.sqf, line 11